### PR TITLE
Add methods to get workspace issues and sprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ workspace_id = client.get_workspace_id('your_workspace_name')
 # Get workspace info
 workspace_info = client.get_workspace_info(workspace_id)
 
+# Get workspace issues
+workspace_issues = client.get_workspace_issues(workspace_id)
+
+# Get workspace sprints
+workspace_sprints = client.get_workspace_sprints(workspace_id)
+
 # Get epic estimate
 epic_data = client.get_epic_estimate('your_epic_id')
 

--- a/lib/zenhub_graphql_api_client.rb
+++ b/lib/zenhub_graphql_api_client.rb
@@ -229,7 +229,7 @@ module ZenhubGraphQLApiClient
       end
     end
 
-    def get_all_issues_in_workspace(workspace_id)
+    def get_workspace_issues(workspace_id)
       query = <<~GRAPHQL
         query workspaceIssues($workspaceId: ID!) {
           workspace(id: $workspaceId) {
@@ -256,6 +256,42 @@ module ZenhubGraphQLApiClient
         response_body['data']['workspace']['issues']['nodes']
       else
         puts "Could not retrieve issue data for workspace ID: #{workspace_id}."
+        puts "Response body: #{response_body}"
+        return nil
+      end
+    end
+
+    def get_workspace_sprints(workspace_id)
+      query = <<~GRAPHQL
+        query workspaceSprints($workspaceId: ID!) {
+          workspace(id: $workspaceId){
+            sprints{
+              totalCount
+              nodes {
+                id
+                name
+                completedPoints
+                closedIssuesCount
+                state
+                startAt
+                endAt
+              }
+            }
+          }
+        }
+      GRAPHQL
+
+      response_body = execute_query(query, { workspaceId: workspace_id })
+
+      if response_body['errors']
+        puts "Error fetching sprint info: #{response_body['errors'].map { |e| e['message'] }.join(', ')}"
+        return nil
+      end
+
+      if response_body['data'] && response_body['data']['workspace'] && response_body['data']['workspace']['sprints']
+        response_body['data']['workspace']['sprints']
+      else
+        puts "Could not retrieve sprint data for workspace ID: #{workspace_id}."
         puts "Response body: #{response_body}"
         return nil
       end


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added new methods to fetch workspace issues and sprints from the ZenHub API.

- **New Features**
  - Added get_workspace_issues to retrieve all issues in a workspace.
  - Added get_workspace_sprints to fetch sprint details for a workspace.
  - Updated README with usage examples for the new methods.

<!-- End of auto-generated description by cubic. -->

